### PR TITLE
Fix #1066 bug readonly property with WKWebView

### DIFF
--- a/src/js/product.js
+++ b/src/js/product.js
@@ -228,7 +228,7 @@ store.Product.prototype.verify = function() {
             }));
             var dataTransaction = getData(data, 'transaction');
             if (dataTransaction) {
-                that.transaction = Object.assign(that.transaction || {}, dataTransaction);
+                that.transaction = Object.assign({}, that.transaction || {}, dataTransaction);
                 store._extractTransactionFields(that);
                 that.trigger("updated");
             }


### PR DESCRIPTION
Unsure how a readonly property might get in `product.transaction`, but this
fixes the issue and still does what it should.

Thanks @nvahalik

Changes proposed in this pull request:

-
-

---

To test this pull request with cordova:

```
# 1: Uninstall the plugin (if already installed)
cordova plugin rm cordova-plugin-purchase

# 2: Install from github
cordova plugin add "https://github.com/j3k0/cordova-plugin-purchase.git#BRANCH_NAME_HERE"
```
